### PR TITLE
Add retry logic for failed network requests

### DIFF
--- a/src/DrawingServer.js
+++ b/src/DrawingServer.js
@@ -5,10 +5,9 @@ export default class DrawingServer {
 	async retryUntilSuccess(url, body) {
 		let response
 		do {
-			response = await (await fetch(url, body))
+			response = await fetch(url, body)
 			if (response.status != 200) console.warn('retrying', {url, body})
-		}
-		while (response.status != 200)
+		} while (response.status != 200)
 
 		return response
 	}

--- a/src/DrawingServer.js
+++ b/src/DrawingServer.js
@@ -1,24 +1,34 @@
 const baseUrl = "http://localhost:1337";
 
 export default class DrawingServer {
-  async addPoints(points) {
-    return await (
-      await fetch(`${baseUrl}/points/add`, {
-        method: "POST",
-        body: JSON.stringify(points),
-        cache: "no-cache",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
-    ).json();
-  }
 
-  async getPoints() {
-    return await (await fetch(`${baseUrl}/points`)).json();
-  }
+	async retryUntilSuccess(url, body) {
+		let response
+		do {
+			response = await (await fetch(url, body))
+			if (response.status != 200) console.warn('retrying', {url, body})
+		}
+		while (response.status != 200)
 
-  async reset() {
-    return await (await fetch(`${baseUrl}/reset`)).json();
-  }
+		return response
+	}
+
+	async addPoints(points) {
+		return await(await this.retryUntilSuccess(`${baseUrl}/points/add`, {
+			method: "POST",
+			body: JSON.stringify(points),
+			cache: "no-cache",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		})).json()
+	}
+
+	async getPoints() {
+		return await (await this.retryUntilSuccess(`${baseUrl}/points`)).json();
+	}
+
+	async reset() {
+		return await (await this.retryUntilSuccess(`${baseUrl}/reset`)).json();
+	}
 }


### PR DESCRIPTION
Adds logic so that any fetch call to an api endpoint will retry continuously until it gets a 200 response